### PR TITLE
fix: restore language selector and fix login page top margin

### DIFF
--- a/adminer/static/default.css
+++ b/adminer/static/default.css
@@ -133,11 +133,13 @@ input.wayoff { left: -1000px; position: absolute; }
 #logins, #tables { white-space: nowrap; overflow: hidden; }
 #logins a, #tables a, #tables span { background: var(--bg); }
 #content { margin: 2.5em 0 0 21em; padding: var(--space-5) var(--space-6) var(--space-6) var(--space-5); }
-#lang { position: absolute; top: -2.6em; left: 0; padding: .3em 1em; }
+#lang { padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--color-border); font-size: 13px; }
 #menuopen { display: none; }
 #breadcrumb { white-space: nowrap; position: absolute; top: 0; left: 21em; background: var(--color-surface-raised); border-bottom: 1px solid var(--color-border); height: 2.5em; line-height: 2.5em; padding: 0 var(--space-5); margin: 0; font-size: 13px; color: var(--color-muted); }
 #breadcrumb a { color: var(--color-muted); text-decoration: none; }
 #breadcrumb a:hover { color: var(--color-primary); }
+/* Login page has no breadcrumb bar — remove top gap */
+body:has(table.layout) #content { margin-top: 0; }
 #logo { vertical-align: baseline; margin-bottom: -3px; }
 #menu h1 { font-size: 16px; margin: 0; padding: var(--space-4) var(--space-4) var(--space-3); border-bottom: 1px solid var(--color-border); font-weight: 600; color: var(--color-text); background: var(--color-surface-raised); display: flex; align-items: center; gap: var(--space-2); }
 #h1 { color: var(--color-text); text-decoration: none; font-style: normal; display: flex; align-items: center; gap: var(--space-2); }
@@ -287,7 +289,7 @@ table.layout ~ label input[type="checkbox"] {
 .rtl #breadcrumb { left: auto; right: 21em; margin: 0; }
 .rtl .pages { left: auto; right: 21em; }
 .rtl input.wayoff { left: auto; right: -1000px; }
-.rtl #lang, .rtl #menu { left: auto; right: 0; }
+.rtl #menu { left: auto; right: 0; }
 .rtl pre, .rtl code { direction: ltr; }
 
 @media all and (max-width: 800px) {
@@ -295,7 +297,6 @@ table.layout ~ label input[type="checkbox"] {
 	.js .logout { top: 1.667em; background: var(--color-surface-raised); border: none; box-shadow: none; border-bottom: 1px solid var(--color-border); }
 	#menu { position: static; width: auto; min-width: 23em; background: var(--color-surface); border: 1px solid var(--color-border); border-right: none; margin-top: 9px; box-shadow: var(--shadow-md); }
 	#content { margin-left: 10px !important; }
-	#lang { position: static; }
 	#breadcrumb { left: 48px !important; }
 	.js #foot { position: absolute; top: 2em; left: 0; }
 	.js .foot { display: none; }


### PR DESCRIPTION
#lang was using position:absolute; top:-2.6em inside #menu to float above the old sidebar (which started at top:2em). After Phase 2b moved #menu to top:0, this placed #lang 2.6em above the viewport — invisible.

Fix #lang to flow naturally inside the sidebar (position: static), matching the new sidebar layout where it renders below #menu h1.

Also add body:has(table.layout) #content { margin-top: 0 } for the login page, which has no breadcrumb bar — removing the 2.5em dead gap at the top of the content area on that page.

Cleanup: remove now-redundant #lang { position: static } from the mobile media query, and drop #lang from the RTL rule (no longer absolutely positioned, so left/right don't apply).