### PR TITLE
feat: responsive layout and dark mode polish (#42, #43)

### DIFF
--- a/adminer/static/dark.css
+++ b/adminer/static/dark.css
@@ -1,6 +1,8 @@
 /** @author Robert Mesaros, https://www.rmsoft.sk */
 
-html {
+/* TASK-DARK-05: dual selector supports prefers-color-scheme AND dark-switcher plugin body.dark class */
+html,
+body.dark {
 	/* Legacy variables */
 	--bg: #002240;
 	--fg: #829bb0;
@@ -22,6 +24,11 @@ html {
 	--color-error-text: #fca5a5;
 	--color-error-border: #991b1b;
 }
+
+/* TASK-DARK-02: native form control color scheme */
+input,
+select,
+textarea { color-scheme: dark; }
 
 a, a:visited { color: #618cb3; }
 a:link:hover, a:visited:hover { color: #9bc0e1; }

--- a/adminer/static/default.css
+++ b/adminer/static/default.css
@@ -351,13 +351,30 @@ table.layout ~ label input[type="checkbox"] {
 
 @media all and (max-width: 800px) {
 	.pages { left: auto; }
-	.js .logout { top: 1.667em; background: var(--color-surface-raised); border: none; box-shadow: none; border-bottom: 1px solid var(--color-border); }
-	#menu { position: static; width: auto; min-width: 23em; background: var(--color-surface); border: 1px solid var(--color-border); border-right: none; margin-top: 9px; box-shadow: var(--shadow-md); }
-	#content { margin-left: 10px !important; }
-	#breadcrumb { left: 48px !important; }
-	.js #foot { position: absolute; top: 2em; left: 0; }
+
+	/* TASK-RESP-05: Mobile logout bar */
+	.js .logout { top: 1.667em; background-color: var(--color-surface-raised); box-shadow: 0 0 5px 5px var(--color-surface-raised); border: none; border-radius: 0; font-size: 12px; }
+
+	/* TASK-RESP-01: Sidebar overlay — fixed + backdrop */
+	#menu { position: static; width: 280px; min-width: unset; background: var(--color-surface); border: none; border-right: 1px solid var(--color-border); box-shadow: var(--shadow-md); margin: 0; }
+	.js #foot { position: fixed; top: 2.5em; left: 0; z-index: 100; max-height: calc(100vh - 2.5em); overflow-y: auto; }
+	.js #foot::before { content: ''; position: fixed; inset: 0; background: rgba(0,0,0,0.3); z-index: -1; }
 	.js .foot { display: none; }
+	.js .foot::before { display: none; }
 	.js #menuopen { display: block; position: absolute; top: 3px; left: 6px; }
+
+	/* TASK-RESP-02: Touch targets */
+	#tables a, #logins a, #menu .links a { min-height: 44px; display: flex; align-items: center; padding: var(--space-2) var(--space-4); }
+	#menuopen { min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center; }
+
+	/* TASK-RESP-03: Breadcrumb overflow */
+	#breadcrumb { left: 48px !important; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: calc(100vw - 60px); }
+
+	/* TASK-RESP-04: Scrollable touch + stacked fieldsets */
+	.scrollable { -webkit-overflow-scrolling: touch; }
+	fieldset { display: block; width: 100%; box-sizing: border-box; margin-right: 0; }
+
+	#content { margin-left: 10px !important; }
 	.nojs #menu { position: static; }
 	.rtl.js #foot { left: auto; right: 0; }
 	.rtl .pages { right: auto; }


### PR DESCRIPTION
## Summary

Two final modernization specs, both CSS-only across `default.css` and `dark.css`.

## Changes

### TASK-RESP-01 through RESP-05 (#42) — `default.css`

| Task | Change |
|---|---|
| RESP-01 | Sidebar overlay: `position:fixed` (was `absolute`), z-index 100, max-height scroll, `::before` backdrop |
| RESP-02 | Touch targets 44px: `#tables a`, `#logins a`, `#menu .links a`, `#menuopen` |
| RESP-03 | Breadcrumb: `text-overflow: ellipsis`, `max-width: calc(100vw - 60px)` |
| RESP-04 | `fieldset` stacks vertically on mobile; `.scrollable` `-webkit-overflow-scrolling: touch` |
| RESP-05 | `.js .logout`: 12px font, surface-raised bg with box-shadow |

### TASK-DARK-01 through DARK-05 (#43) — `dark.css`

| Task | Change |
|---|---|
| DARK-05 | `html {}` → `html, body.dark {}` dual selector for `dark-switcher.php` plugin |
| DARK-02 | `input, select, textarea { color-scheme: dark }` for native control theming |
| DARK-01/03/04 | All tokens already present from TASK-CSS-03; schema cards covered by tokens |

## Safety notes
- `.js .foot` / `.foot` CSS class toggle (JS toggle behavior) preserved intact
- RTL overrides (`.rtl.js #foot`, `.rtl #content`, etc.) preserved
- `#menuopen` click handler and JS behavior unchanged (CSS only)
- `dark-switcher.php` plugin does not need PHP changes — body.dark already set
- Print media query untouched
- No PHP files modified

## Spec references
- `specs/12-responsive-layout.md`
- `specs/13-dark-mode.md`

Closes #42
Closes #43