### PR TITLE
feat: redesign login page to clean centered layout

### DIFF
--- a/adminer/static/default.css
+++ b/adminer/static/default.css
@@ -201,12 +201,39 @@ td i { color: var(--color-muted); font-style: italic; font-size: 12px; }
 body:not(:has(.logout)) #foot { display: none; }
 body:not(:has(.logout)) #menuopen { display: none; }
 body:not(:has(.logout)) #breadcrumb { display: none; }
+/* Constrain error/message banners to the form width on login page */
+body:not(:has(.logout)) .error,
+body:not(:has(.logout)) .message {
+    max-width: 420px;
+    width: 100%;
+    margin-bottom: var(--space-4);
+}
 body:not(:has(.logout)) #content {
     margin: 0;
-    padding: var(--space-6) var(--space-4);
     min-height: 100vh;
     background: var(--color-surface-raised);
     box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-6) var(--space-4);
+}
+/* Login: large centered heading */
+body:not(:has(.logout)) h2 {
+    font-size: 28px;
+    font-weight: 700;
+    text-align: center;
+    color: var(--color-text);
+    margin: 0 0 var(--space-6);
+    border: none;
+    background: none;
+    padding: 0;
+}
+/* Login: constrain form width */
+body:not(:has(.logout)) form {
+    width: 100%;
+    max-width: 420px;
 }
 #logo { vertical-align: baseline; margin-bottom: -3px; }
 #menu h1 { font-size: 16px; margin: 0; padding: var(--space-4) var(--space-4) var(--space-3); border-bottom: 1px solid var(--color-border); font-weight: 600; color: var(--color-text); background: var(--color-surface-raised); display: flex; align-items: center; gap: var(--space-2); }
@@ -229,16 +256,16 @@ body:not(:has(.logout)) #content {
 
 /* ─── Login screen ─────────────────────────────────────────────────────────── */
 
-/* TASK-LOGIN-01: Login card */
+/* TASK-LOGIN-01: Login form fields — no card, clean stacked layout */
 table.layout {
     display: block;
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-md);
-    padding: var(--space-6);
-    margin: var(--space-6) auto;
-    max-width: 380px;
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    margin: 0 auto var(--space-4);
+    max-width: 420px;
+    width: 100%;
     border-spacing: 0;
 }
 table.layout tr {
@@ -247,14 +274,14 @@ table.layout tr {
     margin-bottom: var(--space-4);
 }
 table.layout th {
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--color-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    padding: 0 0 var(--space-1) 0;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text);
+    padding: 0 0 var(--space-2) 0;
     border: none;
     background: none;
+    letter-spacing: 0;
+    text-transform: none;
 }
 table.layout td {
     padding: 0;
@@ -263,7 +290,7 @@ table.layout td {
 table.layout input,
 table.layout select {
     width: 100%;
-    padding: var(--space-2) var(--space-3);
+    padding: 10px var(--space-3);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
     font-size: var(--font-size-base);
@@ -271,6 +298,7 @@ table.layout select {
     background: var(--color-surface);
     color: var(--color-text);
     box-sizing: border-box;
+    transition: border-color 0.15s, outline 0.15s;
 }
 table.layout input:focus,
 table.layout select:focus {
@@ -279,30 +307,30 @@ table.layout select:focus {
     border-color: var(--color-primary);
 }
 
-/* TASK-LOGIN-02: Login submit button — full width below the card */
+/* TASK-LOGIN-02: Submit button — full width, tall, below fields */
 table.layout + p {
-    max-width: 380px;
+    max-width: 420px;
+    width: 100%;
     margin: 0 auto;
-    padding: 0 var(--space-6);
+    padding: 0;
 }
 table.layout + p > input[type="submit"] {
     width: 100%;
     display: block;
-    padding: var(--space-2) var(--space-5);
+    padding: 12px var(--space-5);
     background: var(--color-primary);
     color: #fff;
-    border: 1px solid var(--color-primary);
+    border: none;
     border-radius: var(--radius-sm);
     font-size: var(--font-size-base);
     font-family: var(--font-body);
-    font-weight: 500;
+    font-weight: 600;
     cursor: pointer;
-    transition: background 0.15s, border-color 0.15s;
+    transition: background 0.15s;
     margin-top: var(--space-2);
 }
 table.layout + p > input[type="submit"]:hover {
     background: var(--color-primary-hover);
-    border-color: var(--color-primary-hover);
 }
 table.layout + p > input[type="submit"]:focus-visible {
     outline: 2px solid var(--color-primary);
@@ -314,9 +342,10 @@ table.layout ~ label {
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    max-width: 380px;
+    max-width: 420px;
+    width: 100%;
     margin: var(--space-3) auto 0;
-    padding: 0 var(--space-6);
+    padding: 0;
     font-size: 13px;
     color: var(--color-muted);
     cursor: pointer;


### PR DESCRIPTION
Matches the reference design: vertically centered on a neutral gray bg, large bold heading, no card border/shadow, clean stacked fields.

Changes (CSS-only, no PHP):
- #content on login: flex column, align+justify center, min-height 100vh
- h2 on login: 28px/700 bold, centered, no border, no bg tint
- form on login: max-width 420px, full-width
- table.layout: remove border/shadow/padding — flat transparent layout
- table.layout th: 13px/500 normal weight, no uppercase, label style
- table.layout inputs: 10px vertical padding for taller touch target
- Submit button: 12px vertical padding, font-weight 600, no border
- .error/.message: constrained to 420px, same width as form
- table.layout + p: no horizontal padding (was var(--space-6) on each side)
- table.layout ~ label: full 420px width, no horizontal padding