### PR TITLE
feat: PHP HTML layer — additive wrapper elements (#57)

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -981,12 +981,14 @@ class Adminer {
 	* @param string $missing can be "auth" if there is no database connection, "db" if there is no database selected, "ns" with invalid schema
 	*/
 	function navigation(string $missing): void {
+		echo "<div class='nav-brand'>\n";
 		echo "<h1>" . adminer()->name() . " <span class='version'>" . VERSION;
 		$new_version = $_COOKIE["adminer_version"];
 		echo " <a href='https://www.adminer.org/#download'" . target_blank() . " id='version'>" . (version_compare(VERSION, $new_version) < 0 ? h($new_version) : "") . "</a>";
 		echo "</span></h1>\n";
 		// this is matched by compile.php
 		switch_lang();
+		echo "</div>\n";
 		if ($missing == "auth") {
 			$output = "";
 			foreach ((array) $_SESSION["pwds"] as $vendor => $servers) {
@@ -1003,7 +1005,9 @@ class Adminer {
 				}
 			}
 			if ($output) {
+				echo "<div class='nav-section'>\n";
 				echo "<ul id='logins'>\n$output</ul>\n" . script("mixin(qs('#logins'), {onmouseover: menuOver, onmouseout: menuOut});");
+				echo "</div>\n";
 			}
 		} else {
 			$tables = array();
@@ -1025,13 +1029,19 @@ class Adminer {
 			if ($in_db && function_exists('Adminer\alter_table')) {
 				$actions[] = '<a href="' . h(ME) . 'create="' . bold($_GET["create"] === "") . ">" . lang('Create table') . "</a>";
 			}
-			echo ($actions ? "<p class='links'>\n" . implode("\n", $actions) . "\n" : "");
+			if ($actions) {
+				echo "<div class='nav-section'>\n";
+				echo "<p class='links'>\n" . implode("\n", $actions) . "\n";
+				echo "</div>\n";
+			}
 			if ($in_db) {
+				echo "<div class='nav-section'>\n";
 				if ($tables) {
 					adminer()->tablesPrint($tables);
 				} else {
 					echo "<p class='message'>" . lang('No tables.') . "</p>\n";
 				}
+				echo "</div>\n";
 			}
 		}
 	}

--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -150,6 +150,7 @@ function auth_error(string $error, array &$permanent) {
 		$_SESSION["token"] = rand(1, 1e6); // this is for next attempt
 	}
 	page_header(lang('Login'), $error, null);
+	echo "<div class='login-wrapper'>\n";
 	echo "<form action='' method='post'>\n";
 	echo "<div>";
 	if (hidden_fields($_POST, array("auth"))) { // expired session
@@ -158,6 +159,7 @@ function auth_error(string $error, array &$permanent) {
 	echo "</div>\n";
 	adminer()->loginForm();
 	echo "</form>\n";
+	echo "</div>\n";
 	page_footer("auth");
 	exit;
 }

--- a/adminer/include/design.inc.php
+++ b/adminer/include/design.inc.php
@@ -161,6 +161,10 @@ function get_nonce(): string {
 function page_messages(string $error): void {
 	$uri = preg_replace('~^[^?]*~', '', $_SERVER["REQUEST_URI"]);
 	$messages = idx($_SESSION["messages"], $uri);
+	$has_messages = ($messages || $error || adminer()->error);
+	if ($has_messages) {
+		echo "<div class='page-messages'>\n";
+	}
 	if ($messages) {
 		echo "<div class='message'>" . implode("</div>\n<div class='message'>", $messages) . "</div>" . script("messagesPrint();");
 		unset($_SESSION["messages"][$uri]);
@@ -170,6 +174,9 @@ function page_messages(string $error): void {
 	}
 	if (adminer()->error) { // separate <div>
 		echo "<div class='error'>" . adminer()->error . "</div>\n";
+	}
+	if ($has_messages) {
+		echo "</div>\n";
 	}
 }
 

--- a/adminer/static/default.css
+++ b/adminer/static/default.css
@@ -212,12 +212,17 @@ td i { color: var(--color-muted); font-style: italic; font-size: 12px; }
 body:not(:has(.logout)) #foot { display: none; }
 body:not(:has(.logout)) #menuopen { display: none; }
 body:not(:has(.logout)) #breadcrumb { display: none; }
-/* Constrain error/message banners to the form width on login page */
+/* Constrain messages + form to card width on login page via .login-wrapper */
 body:not(:has(.logout)) .error,
 body:not(:has(.logout)) .message {
     max-width: 420px;
     width: 100%;
-    margin-bottom: var(--space-4);
+}
+body:not(:has(.logout)) .login-wrapper {
+    width: 100%;
+    max-width: 420px;
+    display: flex;
+    flex-direction: column;
 }
 body:not(:has(.logout)) #content {
     margin: 0;
@@ -241,11 +246,16 @@ body:not(:has(.logout)) h2 {
     background: none;
     padding: 0;
 }
-/* Login: constrain form width */
+/* Login: form fills the login-wrapper (max-width set on wrapper) */
 body:not(:has(.logout)) form {
     width: 100%;
-    max-width: 420px;
 }
+/* Nav brand wrapper (h1 + language switcher) — styling via children */
+.nav-brand { display: contents; }
+/* Nav section wrapper (action links, tables list) */
+.nav-section { display: contents; }
+/* Page messages wrapper */
+.page-messages { display: contents; }
 #logo { vertical-align: baseline; margin-bottom: -3px; }
 #menu h1 { font-size: 16px; margin: 0; padding: var(--space-4) var(--space-4) var(--space-3); border-bottom: 1px solid var(--color-border); font-weight: 600; color: var(--color-text); background: var(--color-surface-raised); display: flex; align-items: center; gap: var(--space-2); }
 #h1 { color: var(--color-text); text-decoration: none; font-style: normal; display: flex; align-items: center; gap: var(--space-2); }

--- a/editor/include/adminer.inc.php
+++ b/editor/include/adminer.inc.php
@@ -570,17 +570,20 @@ ORDER BY ORDINAL_POSITION", null, "") as $row
 	}
 
 	function navigation($missing) {
+		echo "<div class='nav-brand'>\n";
 		echo "<h1>" . adminer()->name() . " <span class='version'>" . VERSION;
 		$new_version = $_COOKIE["adminer_version"];
 		echo " <a href='https://www.adminer.org/editor/#download'" . target_blank() . " id='version'>" . (version_compare(VERSION, $new_version) < 0 ? h($new_version) : "") . "</a>";
 		echo "</span></h1>\n";
 		switch_lang();
+		echo "</div>\n";
 		if ($missing == "auth") {
 			$first = true;
 			foreach ((array) $_SESSION["pwds"] as $vendor => $servers) {
 				foreach ($servers[""] as $username => $password) {
 					if ($password !== null) {
 						if ($first) {
+							echo "<div class='nav-section'>\n";
 							echo "<ul id='logins'>";
 							echo script("mixin(qs('#logins'), {onmouseover: menuOver, onmouseout: menuOut});");
 							$first = false;
@@ -589,15 +592,20 @@ ORDER BY ORDINAL_POSITION", null, "") as $row
 					}
 				}
 			}
+			if (!$first) {
+				echo "</div>\n";
+			}
 		} else {
 			adminer()->databasesPrint($missing);
 			if ($missing != "db" && $missing != "ns") {
+				echo "<div class='nav-section'>\n";
 				$table_status = table_status('', true);
 				if (!$table_status) {
 					echo "<p class='message'>" . lang('No tables.') . "\n";
 				} else {
 					adminer()->tablesPrint($table_status);
 				}
+				echo "</div>\n";
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Adds purely additive wrapper `<div>` elements in PHP output methods to provide CSS targeting hooks for deeper UI control. No existing elements are restructured, renamed, or removed.

## Changes

### `adminer/include/auth.inc.php`
- Wrap login `<form>` in `<div class='login-wrapper'>` for scoped form + message sizing

### `adminer/include/design.inc.php`
- Wrap all flash/error messages in `<div class='page-messages'>` (only when messages exist)

### `adminer/include/adminer.inc.php` — `navigation()`
- Wrap `<h1>` + `switch_lang()` in `<div class='nav-brand'>`
- Wrap `<ul id='logins'>` in `<div class='nav-section'>` (auth case)
- Wrap `<p class='links'>` in `<div class='nav-section'>` (non-auth, conditional)
- Wrap tables list in `<div class='nav-section'>` (non-auth, in-db case)

### `editor/include/adminer.inc.php` — `navigation()`
- Mirror: same `nav-brand` + `nav-section` wrappers (editor variant uses `$first` flag pattern)

### `adminer/static/default.css`
- Replace individual form `max-width` rule with `login-wrapper` constraint
- Add `display: contents` stubs for `.nav-brand`, `.nav-section`, `.page-messages` (transparent wrappers — existing descendant CSS rules continue to apply)

## JS-locked elements — not touched
- `<table class='layout'>` rows — untouched
- `#foot > #menu` — untouched  
- `<form id='form'>` — untouched
- `<table id='table'>` — untouched
- `<table id='edit-fields'>` — untouched
- `<span id='selected'>` — untouched

## Tasks skipped
- TASK-PHP-02 (login subtitle): `loginForm()` table rows cannot be wrapped without breaking `loginDriver()` `.rows[1]` hardcoded index
- TASK-PHP-03 (topbar): `#breadcrumb` is `position: absolute; top: 0; left: 21em` — a wrapper div would change its positioning anchor

Closes #57