### PR TITLE
feat: replace login form table with divs for alignment (#59)

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -137,15 +137,20 @@ class Adminer {
 
 	/** Print login form */
 	function loginForm(): void {
-		echo "<table class='layout'>\n";
+		echo "<div class='login-fields'>\n";
 		// this is matched by compile.php
-		echo adminer()->loginFormField('driver', '<tr><th>' . lang('System') . '<td>', html_select("auth[driver]", SqlDriver::$drivers, DRIVER, "loginDriver(this);"));
-		echo adminer()->loginFormField('server', '<tr><th>' . lang('Server') . '<td>', '<input name="auth[server]" value="' . h(SERVER) . '" title="' . lang('hostname[:port] or :socket') . '" placeholder="localhost" autocapitalize="off">');
+		$f = adminer()->loginFormField('driver', '<label>' . lang('System') . '</label>', html_select("auth[driver]", SqlDriver::$drivers, DRIVER, "loginDriver(this);"));
+		if ($f) echo "<div class='login-row'>$f</div>\n";
+		$f = adminer()->loginFormField('server', '<label>' . lang('Server') . '</label>', '<input name="auth[server]" value="' . h(SERVER) . '" title="' . lang('hostname[:port] or :socket') . '" placeholder="localhost" autocapitalize="off">');
+		if ($f) echo "<div class='login-row' id='login-row-server'>$f</div>\n";
 		// this is matched by compile.php
-		echo adminer()->loginFormField('username', '<tr><th>' . lang('Username') . '<td>', '<input name="auth[username]" id="username" autofocus value="' . h($_GET["username"]) . '" autocomplete="username" autocapitalize="off">' . script("const authDriver = qs('#username').form['auth[driver]']; authDriver && authDriver.onchange();"));
-		echo adminer()->loginFormField('password', '<tr><th>' . lang('Password') . '<td>', '<input type="password" name="auth[password]" autocomplete="current-password">');
-		echo adminer()->loginFormField('db', '<tr><th>' . lang('Database') . '<td>', '<input name="auth[db]" value="' . h($_GET["db"]) . '" autocapitalize="off">');
-		echo "</table>\n";
+		$f = adminer()->loginFormField('username', '<label>' . lang('Username') . '</label>', '<input name="auth[username]" id="username" autofocus value="' . h($_GET["username"]) . '" autocomplete="username" autocapitalize="off">' . script("const authDriver = qs('#username').form['auth[driver]']; authDriver && authDriver.onchange();"));
+		if ($f) echo "<div class='login-row'>$f</div>\n";
+		$f = adminer()->loginFormField('password', '<label>' . lang('Password') . '</label>', '<input type="password" name="auth[password]" autocomplete="current-password">');
+		if ($f) echo "<div class='login-row'>$f</div>\n";
+		$f = adminer()->loginFormField('db', '<label>' . lang('Database') . '</label>', '<input name="auth[db]" value="' . h($_GET["db"]) . '" autocapitalize="off">');
+		if ($f) echo "<div class='login-row'>$f</div>\n";
+		echo "</div>\n";
 		echo "<p><input type='submit' value='" . lang('Login') . "'>\n";
 		echo checkbox("auth[permanent]", 1, $_COOKIE["adminer_permanent"], lang('Permanent login')) . "\n";
 	}

--- a/adminer/static/default.css
+++ b/adminer/static/default.css
@@ -351,39 +351,25 @@ input[type="file"] { font-size: 13px; color: var(--color-muted); }
 
 /* ─── Login screen ─────────────────────────────────────────────────────────── */
 
-/* TASK-LOGIN-01: Login form fields — no card, clean stacked layout */
-table.layout {
-    display: block;
-    background: transparent;
-    border: none;
-    box-shadow: none;
-    padding: 0;
-    margin: 0 auto var(--space-4);
-    max-width: 420px;
+/* TASK-LOGIN-01: Login form fields — div-based, clean stacked layout */
+.login-fields {
     width: 100%;
-    border-spacing: 0;
+    margin: 0 0 var(--space-4);
 }
-table.layout tr {
+.login-row {
     display: flex;
     flex-direction: column;
     margin-bottom: var(--space-4);
 }
-table.layout th {
+.login-row label {
+    display: block;
     font-size: 13px;
     font-weight: 500;
     color: var(--color-text);
     padding: 0 0 var(--space-2) 0;
-    border: none;
-    background: none;
-    letter-spacing: 0;
-    text-transform: none;
 }
-table.layout td {
-    padding: 0;
-    border: none;
-}
-table.layout input,
-table.layout select {
+.login-fields input,
+.login-fields select {
     width: 100%;
     padding: 10px var(--space-3);
     border: 1px solid var(--color-border);
@@ -395,21 +381,20 @@ table.layout select {
     box-sizing: border-box;
     transition: border-color 0.15s, outline 0.15s;
 }
-table.layout input:focus,
-table.layout select:focus {
+.login-fields input:focus,
+.login-fields select:focus {
     outline: 2px solid var(--color-primary);
     outline-offset: -1px;
     border-color: var(--color-primary);
 }
 
 /* TASK-LOGIN-02: Submit button — full width, tall, below fields */
-table.layout + p {
-    max-width: 420px;
+.login-fields + p {
     width: 100%;
-    margin: 0 auto;
+    margin: 0;
     padding: 0;
 }
-table.layout + p > input[type="submit"] {
+.login-fields + p > input[type="submit"] {
     width: 100%;
     display: block;
     padding: 12px var(--space-5);
@@ -424,28 +409,27 @@ table.layout + p > input[type="submit"] {
     transition: background 0.15s;
     margin-top: var(--space-2);
 }
-table.layout + p > input[type="submit"]:hover {
+.login-fields + p > input[type="submit"]:hover {
     background: var(--color-primary-hover);
 }
-table.layout + p > input[type="submit"]:focus-visible {
+.login-fields + p > input[type="submit"]:focus-visible {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
 }
 
 /* TASK-LOGIN-03: Permanent login checkbox */
-table.layout ~ label {
+.login-fields ~ label {
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    max-width: 420px;
     width: 100%;
-    margin: var(--space-3) auto 0;
+    margin: var(--space-3) 0 0;
     padding: 0;
     font-size: 13px;
     color: var(--color-muted);
     cursor: pointer;
 }
-table.layout ~ label input[type="checkbox"] {
+.login-fields ~ label input[type="checkbox"] {
     width: auto;
     margin: 0;
 }

--- a/adminer/static/editing.js
+++ b/adminer/static/editing.js
@@ -108,10 +108,10 @@ function messagesPrint(parent) {
 * @param HTMLSelectElement
 */
 function loginDriver(driver) {
-	const trs = parentTag(driver, 'table').rows;
+	const serverRow = qs('#login-row-server');
 	const disabled = /sqlite/.test(selectValue(driver));
-	alterClass(trs[1], 'hidden', disabled);	// 1 - row with server
-	trs[1].getElementsByTagName('input')[0].disabled = disabled;
+	alterClass(serverRow, 'hidden', disabled);
+	serverRow.getElementsByTagName('input')[0].disabled = disabled;
 }
 
 

--- a/editor/include/adminer.inc.php
+++ b/editor/include/adminer.inc.php
@@ -93,10 +93,12 @@ class Adminer {
 	}
 
 	function loginForm() {
-		echo "<table class='layout'>\n";
-		echo adminer()->loginFormField('username', '<tr><th>' . lang('Username') . '<td>', input_hidden("auth[driver]", "server") . '<input name="auth[username]" autofocus value="' . h($_GET["username"]) . '" autocomplete="username" autocapitalize="off">');
-		echo adminer()->loginFormField('password', '<tr><th>' . lang('Password') . '<td>', '<input type="password" name="auth[password]" autocomplete="current-password">');
-		echo "</table>\n";
+		echo "<div class='login-fields'>\n";
+		$f = adminer()->loginFormField('username', '<label>' . lang('Username') . '</label>', input_hidden("auth[driver]", "server") . '<input name="auth[username]" autofocus value="' . h($_GET["username"]) . '" autocomplete="username" autocapitalize="off">');
+		if ($f) echo "<div class='login-row'>$f</div>\n";
+		$f = adminer()->loginFormField('password', '<label>' . lang('Password') . '</label>', '<input type="password" name="auth[password]" autocomplete="current-password">');
+		if ($f) echo "<div class='login-row'>$f</div>\n";
+		echo "</div>\n";
 		echo "<p><input type='submit' value='" . lang('Login') . "'>\n";
 		echo checkbox("auth[permanent]", 1, $_COOKIE["adminer_permanent"], lang('Permanent login')) . "\n";
 	}


### PR DESCRIPTION
## Summary

Replaces `<table class='layout'>` in `loginForm()` with a pure div structure (`div.login-fields` + `div.login-row`) so field widths and the submit button share the same box model, fixing the alignment gap visible in the screenshot.

## Root cause

`<table>` elements have browser-imposed column-sizing behaviour. Even with `display: block` applied via CSS, the `<th>`/`<td>` columns do not stretch to match the full-width `<p> > input[type=submit]` below the table, creating a left/right edge mismatch.

## Changes

### `adminer/include/adminer.inc.php` — `loginForm()`
- `<table class='layout'>` → `<div class='login-fields'>`
- Each row: `<div class='login-row'>` containing `<label>` + input
- Server row: `id='login-row-server'` added for JS targeting
- Each field result stored in `$f` with `if ($f)` guard (handles plugins that return `''` to suppress a field)

### `editor/include/adminer.inc.php` — mirror
- Same div structure for username + password rows

### `adminer/static/editing.js` — `loginDriver()`
- **Before**: `parentTag(driver, 'table').rows[1]` (hardcoded row index)
- **After**: `qs('#login-row-server')` (stable id selector)

### `adminer/static/default.css`
- Removed `table.layout` login-screen block (replaced with `.login-fields` / `.login-row` equivalents)
- `table.layout` CSS for edit-row and dump screens is **kept unchanged**
- `.login-fields + p > input[type=submit]` — full-width button, no `margin: 0 auto` needed
- `.login-fields ~ label` — permanent login checkbox

Closes #59